### PR TITLE
Migrate to UE 4.27

### DIFF
--- a/EasySynth.uplugin
+++ b/EasySynth.uplugin
@@ -26,7 +26,7 @@
 		{
 			"Name": "EasySynth",
 			"Type": "Editor",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "PostDefault"
 		}
 	]
 }

--- a/EasySynth.uplugin
+++ b/EasySynth.uplugin
@@ -2,7 +2,7 @@
 	"FileVersion": 3,
 	"Version": 1,
 	"VersionName": "1.0",
-	"EngineVersion" : "4.26.0",
+	"EngineVersion" : "4.27.0",
 	"WhitelistPlatforms": [ "Win64", "Win32", "Linux" ],
 	"FriendlyName": "EasySynth",
 	"Description": "An Unreal Engine plugin for easy creation of image datasets",

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The plugin works by automatically starting the rendering of a user-defined level
 
 ## Installation
 
-The current main branch of this repo is compatible with Unreal Engine 4.27. For source code or binary builds, for previous engine versions, please consult previous releases.
+The current main branch of this repo is compatible with Unreal Engine 4.27. For source code or binary builds, targeting older engine versions, please consult previous releases.
 
 ### Install inside a specific project
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The plugin works by automatically starting the rendering of a user-defined level
 
 ## Installation
 
-<b>IMPORTANT:</b> The plugin was developed using Unreal Engine 4.26 and it appears not to compile successfully with 4.27. Please use the compatible engine versions until the fix is released.
+The current main branch of this repo is compatible with Unreal Engine 4.27. For source code or binary builds, for previous engine versions, please consult previous releases.
 
 ### Install inside a specific project
 

--- a/Source/EasySynth/Private/EXROutput/MoviePipelineEXROutputLocal.h
+++ b/Source/EasySynth/Private/EXROutput/MoviePipelineEXROutputLocal.h
@@ -57,7 +57,7 @@ public:
 	int32 Height;
 
 	/** A set of key/value pairs to write into the exr file as metadata. */
-	FStringFormatNamedArguments FileMetadata;
+	TMap<FString, FString> FileMetadata;
 
 	/** The image data to write. Supports multiple layers of different bitdepths. */
 	TArray<TUniquePtr<FImagePixelData>> Layers;
@@ -65,9 +65,13 @@ public:
 	/** Optional. A mapping between the FImagePixelData and a name. The standard is that the default layer is nameless (at which point it would be omitted) and other layers are prefixed. */
 	TMap<FImagePixelData*, FString> LayerNames;
 
+	/** Overscan info used to create apropriate dataWindow for EXR output. Goes from 0.0 to 1.0. */
+	float OverscanPercentage;
+
 	FEXRImageWriteTaskLocal()
 		: bOverwriteFile(true)
 		, Compression(EEXRCompressionFormatLocal::PIZ)
+		, OverscanPercentage(0.0f)
 	{}
 
 public:


### PR DESCRIPTION
Needed upgrades to make EasySynth compatible with UE 4.27.
This makes it incompatible with UE 4.26.