### PR TITLE
Custom post-process material render target

### DIFF
--- a/Source/EasySynth/Private/RendererTargets/ColorImageTarget.cpp
+++ b/Source/EasySynth/Private/RendererTargets/ColorImageTarget.cpp
@@ -36,8 +36,18 @@ bool FColorImageTarget::PrepareSequence(ULevelSequence* LevelSequence)
 			UE_LOG(LogEasySynth, Error, TEXT("%s: Found camera is null"), *FString(__FUNCTION__))
 			return false;
 		}
+
 		Camera->PostProcessSettings.WeightedBlendables.Array.Empty();
-		Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, PostProcessMaterial));
+		if (CustomPPMaterial == nullptr)
+		{
+			// If no custom post process material is provided, use the default one
+			Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, PostProcessMaterial));
+		}
+		else
+		{
+			// If a non-null custom post process material is provided, use it instead of the default one
+			Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, CustomPPMaterial));
+		}
 	}
 
 	return true;

--- a/Source/EasySynth/Private/RendererTargets/ColorImageTarget.cpp
+++ b/Source/EasySynth/Private/RendererTargets/ColorImageTarget.cpp
@@ -38,16 +38,7 @@ bool FColorImageTarget::PrepareSequence(ULevelSequence* LevelSequence)
 		}
 
 		Camera->PostProcessSettings.WeightedBlendables.Array.Empty();
-		if (CustomPPMaterial == nullptr)
-		{
-			// If no custom post process material is provided, use the default one
-			Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, PostProcessMaterial));
-		}
-		else
-		{
-			// If a non-null custom post process material is provided, use it instead of the default one
-			Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, CustomPPMaterial));
-		}
+		Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, PostProcessMaterial));
 	}
 
 	return true;

--- a/Source/EasySynth/Private/RendererTargets/CustomPPMaterialTarget.cpp
+++ b/Source/EasySynth/Private/RendererTargets/CustomPPMaterialTarget.cpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 YDrive Inc. All rights reserved.
+
+#include "RendererTargets/CustomPPMaterialTarget.h"
+
+#include "Camera/CameraComponent.h"
+
+#include "LevelSequence.h"
+#include "TextureStyles/TextureStyleManager.h"
+
+
+bool FCustomPPMaterialTarget::PrepareSequence(ULevelSequence* LevelSequence)
+{
+	// Update texture style inside the level
+	TextureStyleManager->CheckoutTextureStyle(ETextureStyle::COLOR);
+
+	// Make sure the custom post process material is not null
+	if (CustomPPMaterial == nullptr)
+	{
+		UE_LOG(LogEasySynth, Error, TEXT("%s: Custom post process material is null"), *FString(__FUNCTION__))
+		return false;
+	}
+
+	// Get all camera components bound to the level sequence
+	TArray<UCameraComponent*> Cameras = GetCameras(LevelSequence);
+	if (Cameras.Num() == 0)
+	{
+		UE_LOG(LogEasySynth, Warning, TEXT("%s: No cameras bound to the level sequence found"), *FString(__FUNCTION__))
+		return false;
+	}
+
+	for (UCameraComponent* Camera : Cameras)
+	{
+		if (Camera == nullptr)
+		{
+			UE_LOG(LogEasySynth, Error, TEXT("%s: Found camera is null"), *FString(__FUNCTION__))
+			return false;
+		}
+
+		Camera->PostProcessSettings.WeightedBlendables.Array.Empty();
+		Camera->PostProcessSettings.WeightedBlendables.Array.Add(FWeightedBlendable(1.0f, CustomPPMaterial));
+	}
+
+	return true;
+}
+
+bool FCustomPPMaterialTarget::FinalizeSequence(ULevelSequence* LevelSequence)
+{
+	return ClearCameraPostProcess(LevelSequence);
+}

--- a/Source/EasySynth/Private/SequenceRenderer.cpp
+++ b/Source/EasySynth/Private/SequenceRenderer.cpp
@@ -42,6 +42,7 @@ bool FRendererTargetOptions::AnyOptionSelected() const
 void FRendererTargetOptions::SetCustomPPMaterialAssetData(const FAssetData& CustomPPMaterialAssetData)
 {
 	CustomPostProcessMaterialAssetData = CustomPPMaterialAssetData;
+	SetSelectedTarget(TargetType::CUSTOM_PP_MATERIAL, CustomPPMaterialAssetData.IsValid());
 }
 
 void FRendererTargetOptions::GetSelectedTargets(
@@ -76,14 +77,15 @@ TSharedPtr<FRendererTarget> FRendererTargetOptions::RendererTarget(
 	const EImageFormat OutputFormat = OutputFormats[TargetType];
 	switch (TargetType)
 	{
-	case COLOR_IMAGE: return MakeShared<FColorImageTarget>(
-		TextureStyleManager, OutputFormat, Cast<UMaterial>(CustomPostProcessMaterialAssetData.GetAsset())); break;
+	case COLOR_IMAGE: return MakeShared<FColorImageTarget>(TextureStyleManager, OutputFormat); break;
 	case DEPTH_IMAGE: return MakeShared<FDepthImageTarget>(
 		TextureStyleManager, OutputFormat, DepthRangeMetersValue); break;
 	case NORMAL_IMAGE: return MakeShared<FNormalImageTarget>(TextureStyleManager, OutputFormat); break;
 	case OPTICAL_FLOW_IMAGE: return MakeShared<FOpticalFlowImageTarget>(
 		TextureStyleManager, OutputFormat, OpticalFlowScaleValue); break;
 	case SEMANTIC_IMAGE: return MakeShared<FSemanticImageTarget>(TextureStyleManager, OutputFormat); break;
+	case CUSTOM_PP_MATERIAL: return MakeShared<FCustomPPMaterialTarget>(
+		TextureStyleManager, OutputFormat, Cast<UMaterial>(CustomPostProcessMaterialAssetData.GetAsset())); break;
 	default: return nullptr;
 	}
 }

--- a/Source/EasySynth/Private/SequenceRenderer.cpp
+++ b/Source/EasySynth/Private/SequenceRenderer.cpp
@@ -39,6 +39,11 @@ bool FRendererTargetOptions::AnyOptionSelected() const
 	return false;
 }
 
+void FRendererTargetOptions::SetCustomPPMaterialAssetData(const FAssetData& CustomPPMaterialAssetData)
+{
+	CustomPostProcessMaterialAssetData = CustomPPMaterialAssetData;
+}
+
 void FRendererTargetOptions::GetSelectedTargets(
 	UTextureStyleManager* TextureStyleManager,
 	TQueue<TSharedPtr<FRendererTarget>>& OutTargetsQueue) const
@@ -71,7 +76,8 @@ TSharedPtr<FRendererTarget> FRendererTargetOptions::RendererTarget(
 	const EImageFormat OutputFormat = OutputFormats[TargetType];
 	switch (TargetType)
 	{
-	case COLOR_IMAGE: return MakeShared<FColorImageTarget>(TextureStyleManager, OutputFormat); break;
+	case COLOR_IMAGE: return MakeShared<FColorImageTarget>(
+		TextureStyleManager, OutputFormat, Cast<UMaterial>(CustomPostProcessMaterialAssetData.GetAsset())); break;
 	case DEPTH_IMAGE: return MakeShared<FDepthImageTarget>(
 		TextureStyleManager, OutputFormat, DepthRangeMetersValue); break;
 	case NORMAL_IMAGE: return MakeShared<FNormalImageTarget>(TextureStyleManager, OutputFormat); break;

--- a/Source/EasySynth/Private/Widgets/WidgetManager.cpp
+++ b/Source/EasySynth/Private/Widgets/WidgetManager.cpp
@@ -298,6 +298,23 @@ TSharedRef<SDockTab> FWidgetManager::OnSpawnPluginTab(const FSpawnTabArgs& Spawn
 			.Padding(2)
 			[
 				SNew(STextBlock)
+				.Text(LOCTEXT("CustomPPMaterialSectionTitle", "Optional custom PP material for color images"))
+			]
+			+SScrollBox::Slot()
+			.Padding(2)
+			[
+				SNew(SObjectPropertyEntryBox)
+				.AllowedClass(UMaterial::StaticClass())
+				.ObjectPath_Raw(this, &FWidgetManager::GetCustomPPMaterialPath)
+				.OnObjectChanged_Raw(this, &FWidgetManager::OnCustomPPMaterialSelected)
+				.AllowClear(true)
+				.DisplayUseSelected(true)
+				.DisplayBrowse(true)
+			]
+			+SScrollBox::Slot()
+			.Padding(2)
+			[
+				SNew(STextBlock)
 				.Text(LOCTEXT("OpticalFlowScaleText", "Optical flow scale coefficient"))
 			]
 			+SScrollBox::Slot()
@@ -443,6 +460,21 @@ FText FWidgetManager::SelectedOutputFormat(const FRendererTargetOptions::TargetT
 	}
 }
 
+void FWidgetManager::OnCustomPPMaterialSelected(const FAssetData& AssetData)
+{
+	SequenceRendererTargets.SetCustomPPMaterialAssetData(AssetData);
+}
+
+FString FWidgetManager::GetCustomPPMaterialPath() const
+{
+	const auto& CustomPPMaterialAssetData = SequenceRendererTargets.CustomPPMaterial();
+	if (CustomPPMaterialAssetData.IsValid())
+	{
+		return CustomPPMaterialAssetData.ObjectPath.ToString();
+	}
+	return "";
+}
+
 bool FWidgetManager::GetIsRenderImagesEnabled() const
 {
 	return
@@ -522,10 +554,8 @@ void FWidgetManager::LoadWidgetOptionStates()
 	// Try to load
 	UWidgetStateAsset* WidgetStateAsset = LoadObject<UWidgetStateAsset>(nullptr, *FPathUtils::WidgetStateAssetPath());
 
-
 	if (WidgetStateAsset != nullptr)
 	{
-
 		// Initialize the widget members using loaded options
 		LevelSequenceAssetData = FAssetData(WidgetStateAsset->LevelSequenceAssetPath.TryLoad());
 		SequenceRendererTargets.SetExportCameraPoses(WidgetStateAsset->bCameraPosesSelected);

--- a/Source/EasySynth/Public/RendererTargets/ColorImageTarget.h
+++ b/Source/EasySynth/Public/RendererTargets/ColorImageTarget.h
@@ -15,8 +15,12 @@ class UTextureStyleManager;
 class FColorImageTarget : public FRendererTarget
 {
 public:
-	explicit FColorImageTarget(UTextureStyleManager* TextureStyleManager, const EImageFormat ImageFormat) :
-		FRendererTarget(TextureStyleManager, ImageFormat)
+	explicit FColorImageTarget(
+			UTextureStyleManager* TextureStyleManager,
+			const EImageFormat ImageFormat,
+			UMaterial* CustomPPMaterial) :
+		FRendererTarget(TextureStyleManager, ImageFormat),
+		CustomPPMaterial(CustomPPMaterial)
 	{}
 
 	/** Returns the name of the target */
@@ -27,4 +31,7 @@ public:
 
 	/** Reverts changes made to the sequence by the PrepareSequence */
 	bool FinalizeSequence(ULevelSequence* LevelSequence) override;
+
+private:
+	UMaterial* CustomPPMaterial;
 };

--- a/Source/EasySynth/Public/RendererTargets/ColorImageTarget.h
+++ b/Source/EasySynth/Public/RendererTargets/ColorImageTarget.h
@@ -15,12 +15,8 @@ class UTextureStyleManager;
 class FColorImageTarget : public FRendererTarget
 {
 public:
-	explicit FColorImageTarget(
-			UTextureStyleManager* TextureStyleManager,
-			const EImageFormat ImageFormat,
-			UMaterial* CustomPPMaterial) :
-		FRendererTarget(TextureStyleManager, ImageFormat),
-		CustomPPMaterial(CustomPPMaterial)
+	explicit FColorImageTarget(UTextureStyleManager* TextureStyleManager, const EImageFormat ImageFormat) :
+		FRendererTarget(TextureStyleManager, ImageFormat)
 	{}
 
 	/** Returns the name of the target */
@@ -31,7 +27,4 @@ public:
 
 	/** Reverts changes made to the sequence by the PrepareSequence */
 	bool FinalizeSequence(ULevelSequence* LevelSequence) override;
-
-private:
-	UMaterial* CustomPPMaterial;
 };

--- a/Source/EasySynth/Public/RendererTargets/CustomPPMaterialTarget.h
+++ b/Source/EasySynth/Public/RendererTargets/CustomPPMaterialTarget.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 YDrive Inc. All rights reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "RendererTargets/RendererTarget.h"
+
+class UTextureStyleManager;
+
+
+/**
+ * Class responsible for updating the world properties before the custom PP
+ * material target rendering and restoring them after the rendering
+*/
+class FCustomPPMaterialTarget : public FRendererTarget
+{
+public:
+	explicit FCustomPPMaterialTarget(
+			UTextureStyleManager* TextureStyleManager,
+			const EImageFormat ImageFormat,
+			UMaterial* CustomPPMaterial) :
+		FRendererTarget(TextureStyleManager, ImageFormat),
+		CustomPPMaterial(CustomPPMaterial)
+	{}
+
+	/** Returns the name of the target */
+	virtual FString Name() const { return TEXT("CustomPPMaterial"); }
+
+	/** Prepares the sequence for rendering the target */
+	bool PrepareSequence(ULevelSequence* LevelSequence) override;
+
+	/** Reverts changes made to the sequence by the PrepareSequence */
+	bool FinalizeSequence(ULevelSequence* LevelSequence) override;
+
+private:
+	UMaterial* CustomPPMaterial;
+};

--- a/Source/EasySynth/Public/SequenceRenderer.h
+++ b/Source/EasySynth/Public/SequenceRenderer.h
@@ -4,11 +4,12 @@
 
 #include "CoreMinimal.h"
 
-#include "RendererTargets/RendererTarget.h"
 #include "RendererTargets/ColorImageTarget.h"
+#include "RendererTargets/CustomPPMaterialTarget.h"
 #include "RendererTargets/DepthImageTarget.h"
 #include "RendererTargets/NormalImageTarget.h"
 #include "RendererTargets/OpticalFlowImageTarget.h"
+#include "RendererTargets/RendererTarget.h"
 #include "RendererTargets/SemanticImageTarget.h"
 #include "TextureStyles/TextureStyleManager.h"
 
@@ -27,7 +28,15 @@ class FRendererTargetOptions
 {
 public:
 	/** The enum containing all supported rendering targets */
-	enum TargetType { COLOR_IMAGE, DEPTH_IMAGE, NORMAL_IMAGE, OPTICAL_FLOW_IMAGE, SEMANTIC_IMAGE, COUNT };
+	enum TargetType {
+		COLOR_IMAGE,
+		DEPTH_IMAGE,
+		NORMAL_IMAGE,
+		OPTICAL_FLOW_IMAGE,
+		SEMANTIC_IMAGE,
+		CUSTOM_PP_MATERIAL,
+		COUNT
+	};
 
 	FRendererTargetOptions();
 

--- a/Source/EasySynth/Public/SequenceRenderer.h
+++ b/Source/EasySynth/Public/SequenceRenderer.h
@@ -52,11 +52,17 @@ public:
 	/** Return should camera poses be exported */
 	bool ExportCameraPoses() const { return bExportCameraPoses; }
 
-	/** DepthRangeMetersValue getter */
+	/** DepthRangeMetersValue setter */
 	void SetDepthRangeMeters(const float DepthRangeMeters) { DepthRangeMetersValue = DepthRangeMeters; }
 
-	/** DepthRangeMetersValue setter */
+	/** DepthRangeMetersValue getter */
 	float DepthRangeMeters() const { return DepthRangeMetersValue; }
+
+	/** CustomPostProcessMaterialAssetData setter */
+	void SetCustomPPMaterialAssetData(const FAssetData& CustomPPMaterialAssetData);
+
+	/** CustomPostProcessMaterialAssetData getter */
+	const FAssetData& CustomPPMaterial() const { return CustomPostProcessMaterialAssetData; }
 
 	/** OpticalFlowScaleValue getter */
 	void SetOpticalFlowScale(const float OpticalFlowScale) { OpticalFlowScaleValue = OpticalFlowScale; }
@@ -87,6 +93,9 @@ private:
 	 * Larger values provide the longer range, but also the lower granularity
 	*/
 	float DepthRangeMetersValue;
+
+	/** Currently selected custom post process material asset data */
+	FAssetData CustomPostProcessMaterialAssetData;
 
 	/**
 	 * Multiplying coefficient for optical flow

--- a/Source/EasySynth/Public/Widgets/WidgetManager.h
+++ b/Source/EasySynth/Public/Widgets/WidgetManager.h
@@ -62,6 +62,12 @@ private:
 	/** Returns the selected output format of the target */
 	FText SelectedOutputFormat(const FRendererTargetOptions::TargetType TargetType) const;
 
+	/** Callback function handling the update of the selected custom post processing material */
+	void OnCustomPPMaterialSelected(const FAssetData& AssetData);
+
+	/** Callback function providing the path the the selected custom post processing material asset */
+	FString GetCustomPPMaterialPath() const;
+
 	/** Callback function handling the update of the output directory */
 	void OnOutputDirectoryChanged(const FString& Directory) { OutputDirectory = Directory; }
 

--- a/Source/EasySynth/Public/Widgets/WidgetStateAsset.h
+++ b/Source/EasySynth/Public/Widgets/WidgetStateAsset.h
@@ -63,9 +63,17 @@ public:
 	UPROPERTY(EditAnywhere, Category = "Rendering Targets")
 	bool bSemanticImagesSelected;
 
-	/** Output format for rendering images */
+	/** Output format for semantic images */
 	UPROPERTY(EditAnywhere, Category = "Rendering Targets")
 	int8 bSemanticImagesOutputFormat;
+
+	/** Selected custom PP material asset */
+	UPROPERTY(EditAnywhere, Category = "Rendering Targets")
+	FSoftObjectPath CustomPPMaterialAssetPath;
+
+	/** Output format for custom PP material images */
+	UPROPERTY(EditAnywhere, Category = "Rendering Targets")
+	int8 bCustomPPMaterialOutputFormat;
 
 	/** Selected depth threashold range */
 	UPROPERTY(EditAnywhere, Category = "Additional parameters")


### PR DESCRIPTION
This PR adds a new render target allowing the user to specify a custom post-process material.
This enables the rendering of custom views in addition to the existing standard views.

Fixes #74
Fixes #11

