### PR TITLE
Fix build on UE 5.7: use %hs for ANSI channel name in EXR layer formatting

### DIFF
--- a/Source/EasySynth/Private/EXROutput/MoviePipelineEXROutputLocal.cpp
+++ b/Source/EasySynth/Private/EXROutput/MoviePipelineEXROutputLocal.cpp
@@ -290,7 +290,7 @@ static FString GetChannelName(const FString& InLayerName, const int32 InChannelI
 
 	if (InLayerName.Len() > 0)
 	{
-		return FString::Printf(TEXT("%s.%s"), *InLayerName, ChannelNames[InChannelIndex]);
+		return FString::Printf(TEXT("%s.%hs"), *InLayerName, ChannelNames[InChannelIndex]);
 	}
 	else
 	{


### PR DESCRIPTION
## Problem
EasySynth (v6.0.0, targets UE 5.5) fails to compile on **UE 5.7**. 5.7 added a
compile-time format-string sanitizer (`TCheckedFormatString`) that validates
`FString::Printf` / `UE_LOG` arguments at compile time. In `GetChannelName()`,
`ChannelNames` is a `const char*[]` (ANSI "R"/"G"/"B"/"A"), and it's passed to
`%s` — which expects `TCHAR*` — so the build fails:

    MoviePipelineEXROutputLocal.cpp(293): error C7595:
    '...TCheckedFormatStringPrivate<..., const char *>...':
    call to immediate function is not a constant expression

## Fix
One line — use `%hs` for the ANSI argument, matching the convention already used
in this same file (line 237 uses `%hs` for `Exception.message().c_str()`):

```cpp
- return FString::Printf(TEXT("%s.%s"),  *InLayerName, ChannelNames[InChannelIndex]);
+ return FString::Printf(TEXT("%s.%hs"), *InLayerName, ChannelNames[InChannelIndex]);